### PR TITLE
Fix Terraform test syntax

### DIFF
--- a/advanced.tftest.hcl
+++ b/advanced.tftest.hcl
@@ -16,17 +16,17 @@ run "verify_staging_environment" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script should be created for staging environment"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route")]) > 0
     error_message = "Worker route should be created for staging environment"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset")]) > 0
     error_message = "Ruleset should be created when maintenance is enabled with allowed IPs"
   }
 }
@@ -49,12 +49,12 @@ run "verify_production_environment" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script should be created for production environment"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route")]) > 0
     error_message = "Worker route should be created for production environment"
   }
 }
@@ -80,7 +80,7 @@ run "verify_rfc3339_date_validation" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script should be created with valid maintenance window"
   }
 }
@@ -103,7 +103,7 @@ run "verify_ip_concatenation" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset")]) > 0
     error_message = "Ruleset should be created with multiple IPs"
   }
 }

--- a/basic.tftest.hcl
+++ b/basic.tftest.hcl
@@ -15,17 +15,17 @@ run "test_enabled_maintenance" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script should be created when maintenance is enabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route")]) > 0
     error_message = "Worker route should be created when maintenance is enabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_dns_record")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_dns_record")]) > 0
     error_message = "DNS record should be created when maintenance is enabled"
   }
 }
@@ -47,12 +47,12 @@ run "test_disabled_maintenance" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
     error_message = "Worker route should not be created when maintenance is disabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_dns_record") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_dns_record") && r.type == "create"]) == 0
     error_message = "DNS record should not be created when maintenance is disabled"
   }
 }

--- a/tests/advanced.tftest.hcl
+++ b/tests/advanced.tftest.hcl
@@ -32,17 +32,17 @@ run "verify_staging_environment" {
   
   # Assertions for staging environment (should be enabled)
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) > 0
     error_message = "Worker route should be created in staging environment"
   }
   
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Worker script should be created in staging environment"
   }
   
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) > 0
     error_message = "Ruleset should be created in staging environment for IP bypass"
   }
 }
@@ -79,12 +79,12 @@ run "verify_production_environment" {
   
   # Assertions for production environment (should be disabled)
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
     error_message = "Worker route should not be created in production environment"
   }
   
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) == 0
     error_message = "Ruleset should not be created in production environment"
   }
 }
@@ -112,13 +112,13 @@ run "verify_rfc3339_date_validation" {
   
   # Check that worker config file will be created (indicating valid dates)
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "local_file") && contains(r.address, "worker_config")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "local_file") && contains(r.address, "worker_config")]) > 0
     error_message = "Worker config file should be created with valid RFC3339 dates"
   }
   
   # Check that plan succeeds (no validation errors on dates)
   assert {
-    condition     = length(data.plan_resource_changes) > 0
+    condition     = length(terraform.plan.resource_changes) > 0
     error_message = "Plan should include resource changes with valid RFC3339 dates"
   }
 }
@@ -145,7 +145,7 @@ run "verify_ip_concatenation" {
   
   # Verify ruleset is created for bypassing maintenance
   assert {
-    condition = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) > 0
+    condition = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) > 0
     error_message = "Ruleset should be created for IP bypass when allowed IPs are specified"
   }
   

--- a/tests/basic.tftest.hcl
+++ b/tests/basic.tftest.hcl
@@ -23,22 +23,22 @@ run "test_enabled_maintenance" {
 
   # Assertions for enabled maintenance
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) > 0
     error_message = "Worker route should be created when maintenance is enabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Worker script should be created when maintenance is enabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_record") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_record") && r.type == "create"]) > 0
     error_message = "DNS record should be created when maintenance is enabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) > 0
     error_message = "Ruleset should be created for IP bypass when maintenance is enabled"
   }
 }
@@ -65,17 +65,17 @@ run "test_disabled_maintenance" {
   
   # Assertions for disabled maintenance
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
     error_message = "Worker route should not be created when maintenance is disabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_record") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_record") && r.type == "create"]) == 0
     error_message = "DNS record should not be created when maintenance is disabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_ruleset") && r.type == "create"]) == 0
     error_message = "Ruleset should not be created when maintenance is disabled"
   }
 }

--- a/tests/worker.tftest.hcl
+++ b/tests/worker.tftest.hcl
@@ -23,12 +23,12 @@ run "verify_worker_script_configuration" {
 
   # Test assertions for worker script configuration
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Worker script should be created with the correct name"
   }
   
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) > 0
     error_message = "Worker route should be created when maintenance is enabled"
   }
 }
@@ -61,13 +61,13 @@ run "verify_worker_config_file" {
   
   # Verify the worker config file will be created
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "local_file") && contains(r.address, "worker_config") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "local_file") && contains(r.address, "worker_config") && r.type == "create"]) > 0
     error_message = "Worker config file should be created"
   }
   
   # Verify the worker script creation
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Worker script should be created with configuration settings"
   }
 }
@@ -92,7 +92,7 @@ run "verify_worker_secret_binding" {
   
   # Check the worker script for secret bindings
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Workers script should be created with secret bindings"
   }
   
@@ -122,7 +122,7 @@ run "verify_worker_analytics_binding" {
   
   # Check the worker script for analytics bindings
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Workers script should be created with analytics bindings"
   }
 }
@@ -146,7 +146,7 @@ run "verify_kv_namespace" {
   
   # Verify KV namespace is created when maintenance is enabled
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace") && r.type == "create"]) > 0
     error_message = "KV namespace should be created when maintenance is enabled"
   }
 }
@@ -170,19 +170,19 @@ run "verify_disabled_worker_configuration" {
   
   # Verify worker script is still created (but routes aren't)
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script") && r.type == "create"]) > 0
     error_message = "Worker script should be created even when maintenance is disabled"
   }
   
   # Verify the worker route is not created when maintenance is disabled
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
     error_message = "Worker route should not be created when maintenance is disabled"
   }
   
   # Verify KV namespace is not created when maintenance is disabled
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace") && r.type == "create"]) == 0
     error_message = "KV namespace should not be created when maintenance is disabled"
   }
 }

--- a/worker.tftest.hcl
+++ b/worker.tftest.hcl
@@ -15,7 +15,7 @@ run "verify_worker_script_configuration" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script should be created"
   }
 }
@@ -38,7 +38,7 @@ run "verify_worker_config_file" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "local_file.worker_config")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "local_file.worker_config")]) > 0
     error_message = "Worker config file should be created"
   }
 }
@@ -61,7 +61,7 @@ run "verify_worker_secret_binding" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script with bindings should be created"
   }
 }
@@ -83,7 +83,7 @@ run "verify_worker_analytics_binding" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_script")]) > 0
     error_message = "Worker script with analytics binding should be created"
   }
 }
@@ -105,7 +105,7 @@ run "verify_kv_namespace" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace")]) > 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace")]) > 0
     error_message = "Worker KV namespace should be created when maintenance is enabled"
   }
 }
@@ -127,12 +127,12 @@ run "verify_disabled_worker_configuration" {
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_route") && r.type == "create"]) == 0
     error_message = "Worker route should not be created when maintenance is disabled"
   }
 
   assert {
-    condition     = length([for r in data.plan_resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace") && r.type == "create"]) == 0
+    condition     = length([for r in terraform.plan.resource_changes : r if contains(r.address, "cloudflare_workers_kv_namespace") && r.type == "create"]) == 0
     error_message = "Worker KV namespace should not be created when maintenance is disabled"
   }
 }


### PR DESCRIPTION
## Summary
- Update all tftest.hcl files to use terraform.plan.resource_changes instead of data.plan_resource_changes
- Fixes invalid reference error in Terraform tests caused by using a reserved symbol name

## Test plan
- The CI pipeline should pass with these changes
- No functional changes to the module code itself