### PR TITLE
build(deps-dev): bump @cloudflare/workers-types (with fixes)

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250430.0",
+        "@cloudflare/workers-types": "^4.20250514.0",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
         "@typescript-eslint/parser": "^7.3.1",
         "@vitest/coverage-v8": "^3.1.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250430.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250430.0.tgz",
-      "integrity": "sha512-JWAX7ZhQ7KjkdJwASgG58MZ/pQ15brlnZ9/0YBwDQ0hrJ/LaK392aTRFlj2r/PRKDZ5dOuujRywNYaNpfeFiEA==",
+      "version": "4.20250514.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250514.0.tgz",
+      "integrity": "sha512-zjyqRjoFnAzg7n+mxMxJAbIeOggUXLJTXA8WyT+xGDE+6MF9bSf1ypEULu4DXQQYLf6nDM6NwzLex/8ABTH+Lw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250430.0",
+    "@cloudflare/workers-types": "^4.20250514.0",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "@vitest/coverage-v8": "^3.1.2",


### PR DESCRIPTION
## Description

Updates @cloudflare/workers-types from 4.20250430.0 to 4.20250514.0 in /worker and merges latest fixes from main

## Changes

- Updates worker development dependencies to latest versions
- Incorporates latest fixes from main branch including:
  - Fixed CodeQL configuration issues
  - Removed deprecated resources
  - Fixed test files syntax
  
## Testing

All tests should now pass with these updates.

Note: This supersedes PR #61 with the fixes added.