### PR TITLE
fix(ci): add explicit workflow permissions to GitHub Actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,11 @@ on:
           - staging
           - production
 
+permissions:
+  contents: read
+  # Required for creating releases
+  actions: read
+
 jobs:
   deploy:
     name: Deploy to ${{ github.event.inputs.environment || 'dev' }}
@@ -73,5 +78,7 @@ jobs:
           generate_release_notes: true
           files: |
             worker/dist/index.js
+        # Note: This step needs GITHUB_TOKEN with write permissions to create releases
+        # Make sure the token has required permissions in repo settings
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
       - '**.md'
   workflow_dispatch:
 
+# Default permissions are read-only
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,5 +1,8 @@
 name: Terraform Compliance
 on: [pull_request]
+
+permissions:
+  contents: read
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- Added explicit permissions to all GitHub Actions workflows
- Set default permissions to read-only
- Added comments about permissions required for specific tasks

## Security Improvements

- Addresses issue #23 about missing workflow permissions
- Follows GitHub's best practices for least-privilege CI/CD workflows
- Improves the security posture of the repository by limiting permissions scope