### PR TITLE
fix: validate maintenance window format

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "maintenance_window" {
   })
   default = null
   validation {
-    condition     = var.maintenance_window == null || (can(parsedate(var.maintenance_window.start_time, "RFC3339")) && can(parsedate(var.maintenance_window.end_time, "RFC3339")))
+    condition     = var.maintenance_window == null || (can(timeadd(var.maintenance_window.start_time, "0s")) && can(timeadd(var.maintenance_window.end_time, "0s")))
     error_message = "Maintenance window times must be in RFC3339 format (e.g., 2025-04-06T08:00:00Z)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "maintenance_window" {
   })
   default = null
   validation {
-    condition     = var.maintenance_window == null || (can(timeadd(var.maintenance_window.start_time, "0s")) && can(timeadd(var.maintenance_window.end_time, "0s")))
+    condition     = var.maintenance_window == null || (can(parsedate(var.maintenance_window.start_time)) && can(parsedate(var.maintenance_window.end_time)))
     error_message = "Maintenance window times must be valid timestamps (e.g., 2025-04-06T08:00:00Z)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "maintenance_window" {
   default = null
   validation {
     condition     = var.maintenance_window == null || (can(timeadd(var.maintenance_window.start_time, "0s")) && can(timeadd(var.maintenance_window.end_time, "0s")))
-    error_message = "Maintenance window times must be in RFC3339 format (e.g., 2025-04-06T08:00:00Z)."
+    error_message = "Maintenance window times must be valid timestamps (e.g., 2025-04-06T08:00:00Z)."
   }
 }
 


### PR DESCRIPTION
## Summary
- validate maintenance window timestamps by ensuring they can be parsed via `timeadd`

## Testing
- `npm test`
- `./run-tests.sh` *(fails: terraform is not installed or not in the PATH)*
- `terraform fmt -check -recursive .` *(fails: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951ff0fc2c8327ae0bf7a2045fd44d