### PR TITLE
fix: resolve worker type issues

### DIFF
--- a/worker/src/api.ts
+++ b/worker/src/api.ts
@@ -193,7 +193,7 @@ async function handleUpdateMaintenanceStatus(
     }
     
     // Fetch current config
-    const currentConfig = (await namespace.get('maintenance_config', { type: 'json' })) as MaintenanceConfig || {};
+    const currentConfig = (await namespace.get('maintenance_config', { type: 'json' }) || {}) as MaintenanceConfig;
 
     // Update config
     const newConfig: MaintenanceConfig = {

--- a/worker/src/api.ts
+++ b/worker/src/api.ts
@@ -16,6 +16,17 @@ interface MaintenanceWindowUpdate {
   end_time?: string;
 }
 
+// Interface for stored maintenance configuration
+interface MaintenanceConfig {
+  enabled: boolean;
+  updated_at: string;
+  maintenance_window?: {
+    start_time: string;
+    end_time: string;
+  };
+  [key: string]: unknown;
+}
+
 /**
  * Validate API key from request
  * @param request - The incoming request
@@ -182,15 +193,15 @@ async function handleUpdateMaintenanceStatus(
     }
     
     // Fetch current config
-    const currentConfig = await namespace.get('maintenance_config', { type: 'json' }) || {};
-    
+    const currentConfig = (await namespace.get('maintenance_config', { type: 'json' })) as MaintenanceConfig || {};
+
     // Update config
-    const newConfig = {
+    const newConfig: MaintenanceConfig = {
       ...currentConfig,
       enabled: body.enabled,
       updated_at: new Date().toISOString()
     };
-    
+
     // Update maintenance window if provided
     if (body.start_time && body.end_time) {
       newConfig.maintenance_window = {
@@ -198,7 +209,7 @@ async function handleUpdateMaintenanceStatus(
         end_time: body.end_time
       };
     }
-    
+
     // Save to KV
     await namespace.put('maintenance_config', JSON.stringify(newConfig));
     

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -43,15 +43,16 @@ try {
 import { handleApiRequest } from './api';
 
 // Event listener for incoming requests
-addEventListener("fetch", (event: FetchEvent) => {
-  const url = new URL(event.request.url);
-  
+addEventListener("fetch", (event) => {
+  const fetchEvent = event as FetchEvent;
+  const url = new URL(fetchEvent.request.url);
+
   // Route API requests differently
   if (url.pathname.startsWith('/api/')) {
     // @ts-ignore - KVNamespace not in types
-    event.respondWith(handleApiRequest(event.request, typedConfig.api_key || 'default_api_key', MAINTENANCE_CONFIG));
+    fetchEvent.respondWith(handleApiRequest(fetchEvent.request, typedConfig.api_key || 'default_api_key', MAINTENANCE_CONFIG));
   } else {
-    event.respondWith(handleRequest(event.request, event));
+    fetchEvent.respondWith(handleRequest(fetchEvent.request, fetchEvent));
   }
 });
 


### PR DESCRIPTION
## Summary
- define maintenance config type and ensure KV updates handle optional window data
- cast fetch events in worker entry to satisfy strict function signatures

## Testing
- `npm run typecheck`
- `npm test`
- `./run-tests.sh` *(fails: module under test does not declare expected variables)*

------
https://chatgpt.com/codex/tasks/task_e_68951ff0fc2c8327ae0bf7a2045fd44d